### PR TITLE
Modifications to support PVRTexLib not installed to default location

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Features include:
 
 The following software is required to build Cuttlefish:
 
-* [CMake](https://cmake.org/) 3.0.2 or later
+* [CMake](https://cmake.org/) 3.1 or later
 * [FreeImage](http://freeimage.sourceforge.net/) (required, included as a submodule)
 * [GLM](https://glm.g-truc.net/0.9.8/index.html) (required, included as a submodule)
 * [nvidia-texture-tools](https://github.com/castano/nvidia-texture-tools) (optional, included as a submodule)
@@ -104,6 +104,7 @@ The following options may be used when running cmake:
 * `-DCUTTLEFISH_INSTALL=ON|OFF`: Allow installation for Cuttlefish components. This can be useful when embedding in other projects to prevent installations from including Cuttlefish. For example, when statically linking into a shared library. Default is `ON`.
 * `-DCUTTLEFISH_INSTALL_PVRTEXLIB=ON|OFF`: Include the PVRTextTool library with the installation. This allows the installation to be used for machines that don't have PVRTexTool installed, and can avoid adjusting the `PATH` environment variable on some platforms. Default is `ON`.
 * `-DCUTTLEFISH_INSTALL_SET_RPATH=ON|OFF`: Set rpath during install for the library and tool on installation. Set to `OFF` if including in another project that wants to control the rpath. Default is `ON`.
+* `-DPVRTEXLIB_ROOT=directory`: The location of the PVRTexTool library platform subdirectories. If the PVRTexTool library is not installed to the standard location on this machine, this variable can be set to tell CMake where to look for the library. The given folder must contain a subdirectory for the current platform (one of `OSX_x86`, `Linux_x86_64`, `Linux_x86_32`, `Windows_x86_64`, or `Windows_x86_32`) that contains the library files.
 
 Once you have built and installed Cuttlefish, you can find the library by calling `find_package(Cuttlefish CONFIG)` within your CMake files. Libraries and include directories can be accessed through the `Cuttlefish_LIBRARIES` and `Cuttlefish_INCLUDE_DIRS` CMake variables.
 

--- a/cmake/FindPVRTexLib.cmake
+++ b/cmake/FindPVRTexLib.cmake
@@ -22,7 +22,8 @@
 #  PVRTEXLIB_LIBRARIES - The libraries needed to use PVRTexLib
 
 IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  SET( PVRTEXLIB_ROOT "/Applications/Imagination/PowerVR_Graphics/PowerVR_Tools/PVRTexTool/Library" )
+  SET( PVRTEXLIB_ROOT "/Applications/Imagination/PowerVR_Graphics/PowerVR_Tools/PVRTexTool/Library"
+      CACHE PATH "Location of the PVRTexTool library platform subdirectories" )
   find_path(
     PVRTEXLIB_INCLUDE_DIR PVRTexture.h
     PATHS ${PVRTEXLIB_ROOT}/Include
@@ -35,7 +36,8 @@ IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   SET( USE_PTHREAD TRUE )
 
 ELSEIF (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  SET( PVRTEXLIB_ROOT "/opt/Imagination/PowerVR_Graphics/PowerVR_Tools/PVRTexTool/Library" )
+  SET( PVRTEXLIB_ROOT "/opt/Imagination/PowerVR_Graphics/PowerVR_Tools/PVRTexTool/Library"
+       CACHE PATH "Location of the PVRTexTool library platform subdirectories" )
   find_path(
     PVRTEXLIB_INCLUDE_DIR PVRTexture.h
     PATHS ${PVRTEXLIB_ROOT}/Include
@@ -54,7 +56,8 @@ ELSEIF (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   SET( USE_PTHREAD TRUE )
 
 ELSEIF(MSVC)
-  SET( PVRTEXLIB_ROOT "C:/Imagination/PowerVR_Graphics/PowerVR_Tools/PVRTexTool/Library" )
+  SET( PVRTEXLIB_ROOT "C:/Imagination/PowerVR_Graphics/PowerVR_Tools/PVRTexTool/Library"
+       CACHE PATH "Location of the PVRTexTool library platform subdirectories" )
   find_path(
     PVRTEXLIB_INCLUDE_DIR PVRTexture.h
     PATHS ${PVRTEXLIB_ROOT}/Include


### PR DESCRIPTION
* If PVRTexLib is not installed in its default location, the
  PVRTEXLIB_ROOT variable needs to be modified to point to the correct
  location. Previously, this value was hardcoded in a non-cache
  variable. Just setting a same-named cache variable prior to
  including Cuttlefish in a CMakeLists.txt file seems to facilitate
  this, but this behavior isn't well-defined; in CMake > 3.3, no
  documentation says one way or the other if this works, and in <=
  3.2, the documentation specifically says this behavior does not
  work.

  Regardless, it would be nice to support this in a more robust way; a
  reasonable person may install PVRTexLib in a non-standard location,
  so this commit changes the PVRTEXLIB_ROOT variable to be
  an (advanced) cache variable. This allows the location to be
  overridden using the standard CMake cache variable mechanism without
  relying on any undocumentated behaviors.

* Bump the minimum required version of CMake in the README to 3.1 as
  this is the actual lower bound of CMake defined in the top-level CMakeLists.txt