### PR TITLE
Add new save methods to allow stream output instead of always to a file

### DIFF
--- a/lib/include/cuttlefish/Texture.h
+++ b/lib/include/cuttlefish/Texture.h
@@ -25,6 +25,9 @@
 #include <cuttlefish/Export.h>
 #include <cuttlefish/Image.h>
 
+#include <iosfwd>
+#include <vector>
+
 namespace cuttlefish
 {
 
@@ -603,6 +606,14 @@ public:
 	 */
 	const void* data(CubeFace face, unsigned int mipLevel = 0, unsigned int depth = 0) const;
 
+    /**
+     * @brief Saves a texture to an ostream.
+     * @param out An ostream object to write data to. This must be opened in binary mode!
+     * @param fileType The type of the file to save.
+     * @return False if the texture hasn't been converted or the data couldn't be written.
+     */
+    SaveResult save(std::ostream& out, FileType fileType);
+
 	/**
 	 * @brief Saves a texture to a file.
 	 * @param fileName The name of the file to save to.
@@ -611,6 +622,13 @@ public:
 	 */
 	SaveResult save(const char* fileName, FileType fileType = FileType::Auto);
 
+    /**
+     * @brief Saves a texture to a std::vector<char>.
+     * @param out A std::vector<std::uint8_t> to store the data to. This buffer will be resized and overwritten.
+     * @param fileType The type of the file to save.
+     * @return False if the texture hasn't been converted or the data couldn't be written.
+     */
+    SaveResult save(std::vector<std::uint8_t>& out, FileType fileType);
 private:
 	struct Impl;
 	Impl* m_impl;

--- a/lib/src/SaveDds.cpp
+++ b/lib/src/SaveDds.cpp
@@ -18,7 +18,7 @@
 #include "Shared.h"
 #include <cassert>
 #include <cstring>
-#include <fstream>
+#include <ostream>
 
 namespace cuttlefish
 {
@@ -253,7 +253,7 @@ struct DdsHeaderDxt10
 };
 
 template <typename T>
-static bool write(std::ofstream& stream, const T& value)
+static bool write(std::ostream& stream, const T& value)
 {
 	stream.write(reinterpret_cast<const char*>(&value), sizeof(T));
 	return stream.good();
@@ -569,16 +569,12 @@ bool isValidForDds(Texture::Format format, Texture::Type type)
 	return getDdsFormat(format, type, ColorSpace::Linear) != DdsDxt10Format_UNKNOWN;
 }
 
-Texture::SaveResult saveDds(const Texture& texture, const char* fileName)
+Texture::SaveResult saveDds(const Texture& texture, std::ostream& stream)
 {
 	DdsDxt10Format ddsFormat = getDdsFormat(texture.format(), texture.type(),
 		texture.colorSpace());
 	if (ddsFormat == DdsDxt10Format_UNKNOWN)
 		return Texture::SaveResult::Unsupported;
-
-	std::ofstream stream(fileName, std::ofstream::binary);
-	if (!stream.is_open())
-		return Texture::SaveResult::WriteError;
 
 	if (!write(stream, magicNumber))
 		return Texture::SaveResult::WriteError;

--- a/lib/src/SaveDds.h
+++ b/lib/src/SaveDds.h
@@ -23,6 +23,6 @@ namespace cuttlefish
 {
 
 bool isValidForDds(Texture::Format format, Texture::Type type);
-Texture::SaveResult saveDds(const Texture& texture, const char* fileName);
+Texture::SaveResult saveDds(const Texture& texture, std::ostream& stream);
 
 } // namespace cuttlefish

--- a/lib/src/SaveKtx.cpp
+++ b/lib/src/SaveKtx.cpp
@@ -17,7 +17,7 @@
 #include "SaveKtx.h"
 #include <cassert>
 #include <cstring>
-#include <fstream>
+#include <ostream>
 
 #define GL_BYTE                           0x1400
 #define GL_UNSIGNED_BYTE                  0x1401
@@ -1180,7 +1180,7 @@ static bool getFormatInfo(FormatInfo& info, Texture::Format format, Texture::Typ
 }
 
 template <typename T>
-static bool write(std::ofstream& stream, const T& value)
+static bool write(std::ostream& stream, const T& value)
 {
 	stream.write(reinterpret_cast<const char*>(&value), sizeof(T));
 	return stream.good();
@@ -1192,7 +1192,7 @@ bool isValidForKtx(Texture::Format format, Texture::Type type)
 	return getFormatInfo(info, format, type, ColorSpace::Linear);
 }
 
-Texture::SaveResult saveKtx(const Texture& texture, const char* fileName)
+Texture::SaveResult saveKtx(const Texture& texture, std::ostream& stream)
 {
 	static_assert(sizeof(0U) == sizeof(std::uint32_t), "unexpected integer size");
 	static_assert(sizeof(unsigned int) == sizeof(std::uint32_t), "unexpected integer size");
@@ -1201,12 +1201,7 @@ Texture::SaveResult saveKtx(const Texture& texture, const char* fileName)
 	if (!getFormatInfo(info, texture.format(), texture.type(), texture.colorSpace()))
 		return Texture::SaveResult::Unsupported;
 
-	std::ofstream stream(fileName, std::ofstream::binary);
-	if (!stream.is_open())
-		return Texture::SaveResult::WriteError;
-
-	stream.write(header, sizeof(header));
-	if (!stream.good())
+	if (!write(stream, header))
 		return Texture::SaveResult::WriteError;
 
 	if (!write(stream, endianness))

--- a/lib/src/SaveKtx.h
+++ b/lib/src/SaveKtx.h
@@ -23,6 +23,6 @@ namespace cuttlefish
 {
 
 bool isValidForKtx(Texture::Format format, Texture::Type type);
-Texture::SaveResult saveKtx(const Texture& texture, const char* fileName);
+Texture::SaveResult saveKtx(const Texture& texture, std::ostream& stream);
 
 } // namespace cuttlefish

--- a/lib/src/SavePvr.cpp
+++ b/lib/src/SavePvr.cpp
@@ -18,7 +18,7 @@
 #include "Shared.h"
 #include <cassert>
 #include <cstring>
-#include <fstream>
+#include <sstream>
 
 #define PVR_GENERIC_FORMAT(channel0, bits0, channel1, bits1, channel2, bits2, channel3, bits3) \
 	(((uint64_t)(channel0) | ((uint64_t)(channel1) << 8) | ((uint64_t)(channel2) << 16) | \
@@ -470,7 +470,7 @@ static bool getPixelFormat(std::uint64_t& pixelFormat, Texture::Format format,
 }
 
 template <typename T>
-static bool write(std::ofstream& stream, const T& value)
+static bool write(std::ostream& stream, const T& value)
 {
 	stream.write(reinterpret_cast<const char*>(&value), sizeof(T));
 	return stream.good();
@@ -482,7 +482,7 @@ bool isValidForPvr(Texture::Format format, Texture::Type)
 	return getPixelFormat(pixelFormat, format, Texture::Alpha::Standard);
 }
 
-Texture::SaveResult savePvr(const Texture& texture, const char* fileName)
+Texture::SaveResult savePvr(const Texture& texture, std::ostream& stream)
 {
 	static_assert(sizeof(0U) == sizeof(std::uint32_t), "unexpected integer size");
 	static_assert(sizeof(unsigned int) == sizeof(std::uint32_t), "unexpected integer size");
@@ -490,10 +490,6 @@ Texture::SaveResult savePvr(const Texture& texture, const char* fileName)
 	std::uint64_t pixelFormat;
 	if (!getPixelFormat(pixelFormat, texture.format(), texture.alphaType()))
 		return Texture::SaveResult::Unsupported;
-
-	std::ofstream stream(fileName, std::ofstream::binary);
-	if (!stream.is_open())
-		return Texture::SaveResult::WriteError;
 
 	const std::uint32_t version = FOURCC('P', 'V', 'R', 3);
 	if (!write(stream, version))

--- a/lib/src/SavePvr.h
+++ b/lib/src/SavePvr.h
@@ -23,6 +23,6 @@ namespace cuttlefish
 {
 
 bool isValidForPvr(Texture::Format format, Texture::Type type);
-Texture::SaveResult savePvr(const Texture& texture, const char* fileName);
+Texture::SaveResult savePvr(const Texture& texture, std::ostream& stream);
 
 } // namespace cuttlefish


### PR DESCRIPTION
- Texture::save(std::vector<data>&, FileType) - saves to a vector of char
- Texture::save(std::ostream&, FileType) - writes to the provided ostream. The ostream must be in binary mode! (used by the other two methods now)