### PR TITLE
Workaround for FreeImage clamping values of HDR textures to [0,1]

### DIFF
--- a/lib/src/Image.cpp
+++ b/lib/src/Image.cpp
@@ -989,8 +989,7 @@ Image Image::convert(Format format) const
 				FreeImage_ConvertToRGBA16(m_impl->image), m_impl->colorSpace));
 			break;
 		case Format::RGBAF:
-			image.m_impl.reset(Impl::create(
-				FreeImage_ConvertToRGBAF(m_impl->image), m_impl->colorSpace));
+			// Fall back to generic conversion because FreeImage_ConvertToRGBAF clamps to [0,1]
 			break;
 		case Format::Int16:
 			image.m_impl.reset(Impl::create(


### PR DESCRIPTION
FreeImage_ConvertToXXX functions clamp values to a [0,1] range. Breaks HDR texture support because Cuttlefish always does a conversion to RGBAF when going from Image to Texture.

The earliest discussion I could find was in 2015: https://sourceforge.net/p/freeimage/bugs/259/
This has also been reported to [NVIDIA Texture Tools Exporter](https://forums.developer.nvidia.com/t/texture-tools-exporter-clamps-hdr-data-when-exporting-bc6h/196077/5) which resulted in this new [issue ](https://sourceforge.net/p/freeimage/patches/150/) which is still open.
I originally intended to use the solution mentioned in the NVIDIA forum (https://github.com/NVIDIAGameWorks/Falcor/issues/209) but as it turns out Cuttlefish already has a fallback routine that works just as well. So my proposed solution is to always fall back to that routine when converting to RGBAF to avoid clamping of HDR values.