### PR TITLE
Fixed signed BC4 and BC5 only generating positive values

### DIFF
--- a/lib/src/S3tcConverter.cpp
+++ b/lib/src/S3tcConverter.cpp
@@ -406,7 +406,7 @@ void Bc4Converter::compressBlock(void* block, ColorRGBAf* blockColors)
 		for (unsigned int i = 0; i < blockPixels; ++i)
 		{
 			colorBlock[i] =
-				static_cast<std::uint8_t>(std::round(clamp(blockColors[i].r, -1.0f, 1.0f)*0x7F));
+				static_cast<std::int8_t>(std::round(clamp(blockColors[i].r*2.0f-1.0f, -1.0f, 1.0f)*0x7F));
 		}
 
 		assert(m_compressonatorOptions);
@@ -459,9 +459,9 @@ void Bc5Converter::compressBlock(void* block, ColorRGBAf* blockColors)
 		for (unsigned int i = 0; i < blockPixels; ++i)
 		{
 			colorBlock[0][i] =
-				static_cast<std::uint8_t>(std::round(clamp(blockColors[i].r, -1.0f, 1.0f)*0x7F));
+				static_cast<std::int8_t>(std::round(clamp(blockColors[i].r*2.0f-1.0f, -1.0f, 1.0f)*0x7F));
 			colorBlock[1][i] =
-				static_cast<std::uint8_t>(std::round(clamp(blockColors[i].g, -1.0f, 1.0f)*0x7F));
+				static_cast<std::int8_t>(std::round(clamp(blockColors[i].g*2.0f-1.0f, -1.0f, 1.0f)*0x7F));
 		}
 
 		assert(m_compressonatorOptions);

--- a/lib/src/StandardConverter.h
+++ b/lib/src/StandardConverter.h
@@ -141,7 +141,7 @@ public:
 			for (unsigned int c = 0; c < C; ++c)
 			{
 				curData[i*C + c] = static_cast<T>(
-					std::round(clamp(scanline[col*4 + c], -1.0f, 1.0f)*maxVal));
+					std::round(clamp(scanline[col*4 + c]*2.0f-1.0f, -1.0f, 1.0f)*maxVal));
 			}
 		}
 	}


### PR DESCRIPTION
The current implementation of signed BC4 and BC5 is only generating positive values for the endpoints. Before I modified these lines, they mapped the (I assume) [0;1] float range to [0;127] unsigned int, which meant that only the positive half of the full range of representable values was actually being used. Normal map samples had to be remapped to the [-1;1] range manually in the shader, just as if it were an unsigned texture (except for the halved precision!).

With this change, the [0;1] float range is going to be mapped to the [-127;127] int range before compression, allowing negative values in the textures. Note that this is the default behavior in compressonator when compressing a PNG normal map with "compressonatorcli -fd BC5_S", ie color (R=0.5, G=0.5) becomes (R=0, G=0) when sampling the texture.